### PR TITLE
Make 3.4.4 the min possible version in react-scripts

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -11,7 +11,7 @@
     "@types/react-dom": "16.9.4",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "react-scripts": "^3.4.3",
+    "react-scripts": "^3.4.4",
     "typescript": "^4.0.3"
   },
   "scripts": {


### PR DESCRIPTION
Prevent [`object-path`'s security vulnerability](https://github.com/google-pay/google-pay-button/network/alert/examples/react/package-lock.json/object-path/open)