### PR TITLE
fix: call config.onError if present if isReadyToPay throws

### DIFF
--- a/src/lib/button-manager.ts
+++ b/src/lib/button-manager.ts
@@ -245,7 +245,11 @@ export class ButtonManager {
         || (readyToPay.result && readyToPay.paymentMethodPresent && this.config.existingPaymentMethodRequired)
         || false;
     } catch (err) {
-      console.error(err);
+      if (this.config.onError) {
+        this.config.onError(err)
+      } else {
+        console.error(err);
+      }
     }
 
     if (!this.isMounted()) return;

--- a/src/lib/button-manager.ts
+++ b/src/lib/button-manager.ts
@@ -246,7 +246,7 @@ export class ButtonManager {
         || false;
     } catch (err) {
       if (this.config.onError) {
-        this.config.onError(err)
+        this.config.onError(err);
       } else {
         console.error(err);
       }


### PR DESCRIPTION
Currently if the `isReadyToPay` throws when setting up the Google Pay button, the `onError` callback is not called and the error is printed out in console through `console.error` instead. This PR adds support for triggering the `onError` callback if present and otherwise fallback to the existing behaviour.