### PR TITLE
fix: trigger onError callback when loading google pay js failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,5 @@ yarn-error.log*
 
 *.orig
 .env
-.history
 .bit/
 .bitmap

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ yarn-error.log*
 
 *.orig
 .env
+
 .bit/
 .bitmap

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,6 @@ yarn-error.log*
 
 *.orig
 .env
-
+.history
 .bit/
 .bitmap

--- a/src/lib/button-manager.ts
+++ b/src/lib/button-manager.ts
@@ -79,7 +79,7 @@ export class ButtonManager {
     if (!this.isGooglePayLoaded()) {
       try {
         await loadScript('https://pay.google.com/gp/p/js/pay.js');
-      } catch(err) {
+      } catch (err) {
         if (this.config?.onError) {
           this.config.onError(err as Error);
         } else {
@@ -87,8 +87,6 @@ export class ButtonManager {
         }
       }
     }
-
-  
 
     this.element = element;
     if (element) {

--- a/src/lib/button-manager.ts
+++ b/src/lib/button-manager.ts
@@ -76,17 +76,18 @@ export class ButtonManager {
   }
 
   async mount(element: Element): Promise<void> {
-    try {
-      if (!this.isGooglePayLoaded()) {
+    if (!this.isGooglePayLoaded()) {
+      try {
         await loadScript('https://pay.google.com/gp/p/js/pay.js');
-      }
-    } catch(err) {
-      if (this.config?.onError) {
-        this.config.onError(err as Error);
-      } else {
-        console.error(err);
+      } catch(err) {
+        if (this.config?.onError) {
+          this.config.onError(err as Error);
+        } else {
+          console.error(err);
+        }
       }
     }
+
   
 
     this.element = element;

--- a/src/lib/button-manager.ts
+++ b/src/lib/button-manager.ts
@@ -76,9 +76,18 @@ export class ButtonManager {
   }
 
   async mount(element: Element): Promise<void> {
-    if (!this.isGooglePayLoaded()) {
-      await loadScript('https://pay.google.com/gp/p/js/pay.js');
+    try {
+      if (!this.isGooglePayLoaded()) {
+        await loadScript('https://pay.google.com/gp/p/js/pay.js');
+      }
+    } catch(err) {
+      if (this.config?.onError) {
+        this.config.onError(err as Error);
+      } else {
+        console.error(err);
+      }
     }
+  
 
     this.element = element;
     if (element) {


### PR DESCRIPTION
Background: https://pay.google.com/gp/p/js/pay.js will be failed to load in china if the user don't have the agent software. It's better to call the onError callback when loading js errored.



