### PR TITLE
fix: onError callback not called for @google-pay/button-react

### DIFF
--- a/src/button-react/GooglePayButton.tsx
+++ b/src/button-react/GooglePayButton.tsx
@@ -42,8 +42,8 @@ export default class GooglePayButton extends React.Component<Props> {
   async componentDidMount(): Promise<void> {
     const element = this.elementRef.current;
     if (element) {
+      await this.manager.configure(this.props);
       await this.manager.mount(element);
-      this.manager.configure(this.props);
     }
   }
 


### PR DESCRIPTION
Changing the invocation order of `mount` and `configure` will make sure to invoke the `onError` callback if there was an error when trying to load `pay.js`

- fixes #170 