### PR TITLE
fix: do not reference undefined google during component mounting

### DIFF
--- a/src/lib/button-manager.ts
+++ b/src/lib/button-manager.ts
@@ -86,6 +86,7 @@ export class ButtonManager {
           console.error(err);
         }
       }
+      return;
     }
 
     this.element = element;


### PR DESCRIPTION
Without returning from the `mount()` function if there was an error loading `pay.js` we continue to call `this.updateElement();` this will result in trying to reference the undefined `google` object:

https://github.com/google-pay/google-pay-button/blob/812855408177dfa7a022849566bdd298ed477231/src/lib/button-manager.ts#L231

fixes #219 