### PR TITLE
fix: only return from mount() if there was an error

### DIFF
--- a/src/lib/button-manager.ts
+++ b/src/lib/button-manager.ts
@@ -85,8 +85,8 @@ export class ButtonManager {
         } else {
           console.error(err);
         }
+        return;
       }
-      return;
     }
 
     this.element = element;


### PR DESCRIPTION
regression introduced by #220 

If there was an error while trying to load `pay.js` only return from the `mount()` function in case of an error.