### PR TITLE
fix: invalidation values comparison for objects

### DIFF
--- a/src/lib/button-manager.ts
+++ b/src/lib/button-manager.ts
@@ -402,7 +402,9 @@ export class ButtonManager {
     if (!this.oldInvalidationValues) return true;
 
     const newValues = this.getInvalidationValues(newConfig);
-    return newValues.some((value, index) => value !== this.oldInvalidationValues![index]);
+    return newValues.some(
+      (value, index) => JSON.stringify(value) !== JSON.stringify(this.oldInvalidationValues![index]),
+    );
   }
 
   private getInvalidationValues(config: Config): any[] {


### PR DESCRIPTION
The [check](https://github.com/google-pay/google-pay-button/blob/main/src/lib/button-manager.ts#L405) to determine if the client should be invalidate (and therefore the button is redrawn) is flaky for objects like `allowedPaymentMethods`. By using `JSON.stringify(value)` this change makes sure to compare strings. All unit tests validating this behaviour still pass.

This should also fix #228 as `this.updateElement()` will no longer be triggered in this case.